### PR TITLE
Static intel MKL libaries are now used if available and their symbols…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,6 @@ if(SPFFT_ROCM)
 endif()
 
 
-
 if(SPFFT_MPI)
 	find_package(MPI REQUIRED)
 	list(APPEND SPFFT_EXTERNAL_LIBS MPI::MPI_CXX)
@@ -132,7 +131,18 @@ endif()
 
 
 # Use MKL if available, otherwise require FFTW3
+if(UNIX AND NOT APPLE)
+	# prefer static MKL in Linux. Together with "-Wl,--exclude-libs,ALL",
+	# symbols are not visible for linking afterwards and no conflicts with other MKL versions of other libraries should exist.
+	set(_TMP_SAVE ${CMAKE_FIND_LIBRARY_SUFFIXES})
+	set(CMAKE_FIND_LIBRARY_SUFFIXES .a .so)
+endif()
 find_package(MKLSequential)
+if(UNIX AND NOT APPLE)
+	set(CMAKE_FIND_LIBRARY_SUFFIXES ${_TMP_SAVE})
+	unset(_TMP_SAVE)
+endif()
+
 if(MKLSequential_FOUND)
 	list(APPEND SPFFT_EXTERNAL_LIBS MKL::Sequential)
 	if(SPFFT_STATIC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,11 @@ add_library(spfft ${SPFFT_LIBRARY_TYPE}
 
 # Don't export any symbols of external static libaries. Only works on linux.
 if(UNIX AND NOT APPLE)
-	target_link_options(spfft PRIVATE "-Wl,--exclude-libs,ALL")
+	if(${CMAKE_VERSION} VERSION_LESS "3.13.5") 
+		set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "-Wl,--exclude-libs,ALL")
+	else()
+		target_link_options(spfft PRIVATE "-Wl,--exclude-libs,ALL")
+	endif()
 endif()
 
 # add depency on ojbect generating targets for ROCM

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,6 +62,11 @@ add_library(spfft ${SPFFT_LIBRARY_TYPE}
 	${SPFFT_SOURCE_FILES}
 	)
 
+# Don't export any symbols of external static libaries. Only works on linux.
+if(UNIX AND NOT APPLE)
+	target_link_options(spfft PRIVATE "-Wl,--exclude-libs,ALL")
+endif()
+
 # add depency on ojbect generating targets for ROCM
 if(SPFFT_ROCM)
 	add_dependencies(spfft ${ROCM_TARGETS})


### PR DESCRIPTION
… hidden in the resulting shared library. This should help prevent issues with multiple MKL versions.