### PR TITLE
Find debug rocfft lib too

### DIFF
--- a/cmake/modules/FindROCFFT.cmake
+++ b/cmake/modules/FindROCFFT.cmake
@@ -56,7 +56,7 @@ endif()
 
 find_library(
     ROCFFT_LIBRARIES
-    NAMES "rocfft"
+    NAMES "rocfft" "rocfft-d"
     HINTS ${_ROCFFT_PATHS}
     PATH_SUFFIXES "rocfft/lib" "rocfft" 
 )


### PR DESCRIPTION
When building rocfft in debug mode, it adds a suffix `-d` to the library name: `rocfft-d.so`, see https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-3.5.0/library/src/CMakeLists.txt#L93. This PR makes it possible to link against a debug version of rocfft, too.